### PR TITLE
Remap Ctrl+C and Ctrl+D back to itself.

### DIFF
--- a/mac.ahk
+++ b/mac.ahk
@@ -107,3 +107,7 @@ Ctrl & Tab::AltTab
     Suspend(false)
     return
 }
+
+; restore support for Ctrl+C (break) and Ctrl+D (EOF)
+!c::Send("^c")
+!d::Send("^d")


### PR DESCRIPTION
Closes #27.
